### PR TITLE
Fix "Test endopint" to "Test endpoint"

### DIFF
--- a/lib/benchmark/csv_export.ex
+++ b/lib/benchmark/csv_export.ex
@@ -5,7 +5,7 @@ defmodule Benchmark.CSVExport do
     server: "Server",
     treeish: "Treeish",
     protocol: "Protocol",
-    endpoint: "Test endopint",
+    endpoint: "Test endpoint",
     clients: "Number of clients",
     concurrency: "Client concurrency",
     threads: "Number of client threads",


### PR DESCRIPTION
Typo Fix
It seems like there was a small overlooked typo, in the results.

![Screenshot 2024-02-11 at 11 42 53](https://github.com/mtrudel/benchmark/assets/11752260/85be5885-4917-49f4-9375-9ec536bd9507)
