### PR TITLE
perf experiment

### DIFF
--- a/lib/benchmark.ex
+++ b/lib/benchmark.ex
@@ -5,8 +5,8 @@ defmodule Benchmark do
     server_def = parse!(server)
 
     Benchmark.Server.run(server_def, fn ->
-      Benchmark.HTTPClient.run(server_def, args) ++
-        Benchmark.WebSocketClient.run(server_def, args)
+      Benchmark.HTTPClient.run(server_def, args) 
+        #++ Benchmark.WebSocketClient.run(server_def, args)
     end)
   end
 

--- a/lib/benchmark/http_client.ex
+++ b/lib/benchmark/http_client.ex
@@ -58,7 +58,7 @@ defmodule Benchmark.HTTPClient do
 
   defp build_clients(args) do
     case Keyword.get(args, :profile, "normal") do
-      "tiny" -> [1, 4, 16]
+      "tiny" -> [4]
       "normal" -> [2, 4, 16, 64, 256]
       "huge" -> [2, 4, 16, 64, 256, 1024, 4096]
     end

--- a/lib/benchmark/server.ex
+++ b/lib/benchmark/server.ex
@@ -21,7 +21,7 @@ defmodule Benchmark.Server do
   end
 
   defp start_server(server_def) do
-    MuonTrap.Daemon.start_link("elixir", ["-e", server_script(server_def)],
+    MuonTrap.Daemon.start_link("perf", ["record", "-o", "./perf.data", "--call-graph=fp", "--", "elixir", "--erl", "+JPperf true", "-e", server_script(server_def)],
       stderr_to_stdout: true,
       log_output: :debug
     )

--- a/lib/mix/tasks/benchmark.ex
+++ b/lib/mix/tasks/benchmark.ex
@@ -83,7 +83,8 @@ defmodule Mix.Tasks.Benchmark do
             Enum.zip_with(results_a, results_b, fn
               nil, _ -> 0
               0, _ -> 0
-              0.0, _ -> 0
+              +0.0, _ -> 0
+              -0.0, _ -> 0
               _, nil -> 0
               a, b -> 100 * b / a - 100
             end)


### PR DESCRIPTION
Related to https://github.com/mtrudel/benchmark/issues/25. This is a hacked together version of a `perf` test w/ a local bandit install. The problem with the remote install is that it uses `mix` dynamically which I think could skew perf but I have not tested with that. Here is how I ran it:
```
mix benchmark --profile tiny --protocol http/1.1 bandit bandit
```

And this outputs two files, a `perf.data` and a `perf.data.old` between two of the same bandits to ensure this is a reasonable test. I've ran this 2-3 times and using `perf diff` on the resulting files it seems _relatively_ stable between runs. Two annoying parts stick out:
```
# Baseline  Delta Abs  Shared Object         Symbol                                                                                                                                                       >
# ........  .........  ....................  .............................................................................................................................................................>
#
    30.52%     +0.30%  [unknown]             [k] 0xffffffff83c05490
     7.18%     -0.09%  beam.smp              [.] erts_schedule
```

One is `0xffffffff83c05490`, no idea what that could be, and the other is a delta in scheduler time but I guess that is expected.

Here is an example of the heaviest function reported by `perf report`

```
-  11.52% $gen_server:try_handle_info/3
      - 10.90% $'Elixir.Bandit.DelegatingHandler':handle_info/2
         - 10.71% $'Elixir.Bandit.DelegatingHandler':handle_data/3
            - 10.00% $'Elixir.Bandit.HTTP1.Handler':handle_data/3
               - 9.87% $'Elixir.Bandit.Pipeline':run/4
                  - 4.97% $'Elixir.Bandit.Pipeline':'call_plug!'/2
                     - 4.80% $'Elixir.Plug.Conn':send_resp/1
                        - 3.93% $'Elixir.Bandit.Adapter':send_resp/4
                           - 3.09% $'Elixir.Bandit.Adapter':send_headers/4
                              - 2.76% $'Elixir.Bandit.HTTPTransport.Bandit.HTTP1.Socket':send_headers/4
                                 - 2.35% $'Elixir.Bandit.HTTPTransport.Bandit.HTTP1.Socket':'send!'/2
                                    - 2.28% $'Elixir.ThousandIsland.Socket':send/2
                                       - 1.53% $prim_inet:send/4
                                          - 1.27% $erlang:port_command/3
                                             + 0.97% $global::call_light_bif_shared
                  - 1.72% $'Elixir.Bandit.HTTPTransport.Bandit.HTTP1.Socket':read_headers/1
                       0.91% $'Elixir.Bandit.HTTPTransport.Bandit.HTTP1.Socket':'do_read_headers!'/2
                       0.52% $'Elixir.Bandit.HTTPTransport.Bandit.HTTP1.Socket':'do_read_request_line!'/2
                  - 1.65% $'Elixir.Bandit.Pipeline':'build_conn!'/5
                       0.66% $'Elixir.Bandit.TransportInfo':init/1
              0.58% $'Elixir.Bandit.HTTP1.Handler':maybe_keepalive/2
```

Here is what I had to install on Ubuntu:
```
sudo apt install linux-tools-common linux-tools-generic linux-tools-`uname -r`
```

This link is a generally good reference: https://www.erlang.org/doc/apps/erts/beamasm.html#linux-perf-support